### PR TITLE
fix: add Undefined team topology type and fix default

### DIFF
--- a/src/components/inspector/TeamInspector.tsx
+++ b/src/components/inspector/TeamInspector.tsx
@@ -40,6 +40,21 @@ export function TeamInspector({ project, teamId }: { project: Project; teamId: s
       {/* Team Topology Type */}
       <Section label="Team Topology">
         <div className="flex flex-wrap gap-1.5">
+          <button
+            onClick={() => updateTeam(team.id, { topologyType: undefined })}
+            className={`px-2 py-1 text-xs font-medium rounded transition-colors ${
+              !team.topologyType
+                ? 'ring-1'
+                : 'bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-700'
+            }`}
+            style={!team.topologyType ? {
+              backgroundColor: getTopologyColors('unknown').light.bg,
+              color: getTopologyColors('unknown').light.text,
+              '--tw-ring-color': getTopologyColors('unknown').light.border,
+            } as React.CSSProperties : undefined}
+          >
+            Undefined
+          </button>
           {(['stream-aligned', 'platform', 'enabling', 'complicated-subsystem'] as const).map((value) => {
             const isActive = team.topologyType === value
             const colors = isActive ? getTopologyColors(value).light : null

--- a/src/components/inspector/__tests__/TeamInspector.test.tsx
+++ b/src/components/inspector/__tests__/TeamInspector.test.tsx
@@ -74,6 +74,17 @@ describe('TeamInspector', () => {
     expect(mockDeleteTeam).toHaveBeenCalledWith('team-1')
   })
 
+  it('renders the Undefined button', () => {
+    render(<TeamInspector project={makeProject()} teamId="team-1" />)
+    expect(screen.getByText('Undefined')).toBeInTheDocument()
+  })
+
+  it('clicking Undefined button calls updateTeam with topologyType undefined', () => {
+    render(<TeamInspector project={makeProject()} teamId="team-1" />)
+    fireEvent.click(screen.getByText('Undefined'))
+    expect(mockUpdateTeam).toHaveBeenCalledWith('team-1', { topologyType: undefined })
+  })
+
   it('deselects topology type when clicking the already-selected button', () => {
     render(<TeamInspector project={makeProject()} teamId="team-1" />)
     fireEvent.click(screen.getByText('Platform'))

--- a/src/model/store.ts
+++ b/src/model/store.ts
@@ -644,6 +644,9 @@ export const useEditorStore = create<EditorState>((set) => ({
         if ('name' in updates && updates.name !== oldTeam.name) {
           trackTextFieldEdit(project, 'team', 'name', oldTeam.name, updates.name, 'inspector')
         }
+        if ('topologyType' in updates && updates.topologyType !== oldTeam.topologyType) {
+          trackPropertyChange('team_updated', project, 'team', teamId, 'topologyType', oldTeam.topologyType, updates.topologyType, 'inspector')
+        }
       }
     }
     return {}
@@ -657,7 +660,6 @@ export const useEditorStore = create<EditorState>((set) => ({
     const newTeam = {
       id: `team-${Date.now()}`,
       name,
-      topologyType: 'stream-aligned' as const,
     }
     getCollabMutations().addTeam(newTeam)
 


### PR DESCRIPTION
## Summary

- New teams no longer default to `stream-aligned` — topology type is now unset by default, so teams must be consciously classified
- Adds an explicit **Undefined** button in the Team Inspector that highlights when no type is set, making the unclassified state visible alongside the four standard Team Topologies types
- Adds analytics tracking for topology type changes

## Motivation

Assigning a Team Topologies type to a team just by selecting it in the UI is an anti-pattern — renaming a team doesn't make it a Stream-Aligned Team. The previous default of `stream-aligned` silently implied a classification that may not reflect reality. Undefined is now a first-class, visible state.

## Test plan

- [ ] Create a new team — verify it shows **Undefined** highlighted, not Stream
- [ ] Click a topology type — verify it becomes active
- [ ] Click **Undefined** — verify it clears the type and highlights Undefined again
- [ ] Verify the team label overlay shows no topology badge for Undefined teams
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)