### PR TITLE
fix: ownership pills preview canvas colors instead of always-green (#35)

### DIFF
--- a/src/components/inspector/ContextInspector.tsx
+++ b/src/components/inspector/ContextInspector.tsx
@@ -20,8 +20,6 @@ import {
   Activity,
   Archive,
   CloudFog,
-  Building2,
-  ExternalLink,
   DollarSign,
   Heart,
   Shield,
@@ -53,6 +51,7 @@ import {
 } from '../../model/conceptDefinitions'
 import type { ContextOwnership, Project } from '../../model/types'
 import { getConnectedUsers, categorizeRelationships } from '../../lib/inspectorHelpers'
+import { OWNERSHIP_FILL_COLORS } from '../../lib/nodeStyles'
 import { RepoCard } from './ContextRepoCard'
 import { RelationshipGroup } from './RelationshipGroup'
 import { IssueSeverityButton } from './IssueSeverityButton'
@@ -75,18 +74,20 @@ type CodeSizeBucket = NonNullable<NonNullable<Project['contexts'][number]['codeS
 
 const PILL_ICON_CLASS = 'mr-1 align-middle text-current'
 
+function OwnershipSwatch({ ownership }: { ownership: ContextOwnership }) {
+  return (
+    <span
+      aria-hidden
+      className="inline-block rounded-[2px] mr-1.5 align-middle ring-1 ring-black/10 dark:ring-white/15"
+      style={{ width: 12, height: 12, backgroundColor: OWNERSHIP_FILL_COLORS[ownership] }}
+    />
+  )
+}
+
 const OWNERSHIP_OPTIONS: ReadonlyArray<PillOption<ContextOwnership>> = [
-  { value: 'ours', label: 'Our Team', adornment: <Users size={12} className={PILL_ICON_CLASS} /> },
-  {
-    value: 'internal',
-    label: 'Internal',
-    adornment: <Building2 size={12} className={PILL_ICON_CLASS} />,
-  },
-  {
-    value: 'external',
-    label: 'External',
-    adornment: <ExternalLink size={12} className={PILL_ICON_CLASS} />,
-  },
+  { value: 'ours', label: 'Our Team', adornment: <OwnershipSwatch ownership="ours" /> },
+  { value: 'internal', label: 'Internal', adornment: <OwnershipSwatch ownership="internal" /> },
+  { value: 'external', label: 'External', adornment: <OwnershipSwatch ownership="external" /> },
 ]
 
 const ROLE_OPTIONS: ReadonlyArray<PillOption<BusinessModelRole>> = [
@@ -375,7 +376,7 @@ export function ContextInspector({ project, contextId }: { project: Project; con
             value={(context.ownership || 'ours') as ContextOwnership}
             onChange={(next) => handleUpdate({ ownership: (next ?? 'ours') as ContextOwnership })}
             layout="horizontal"
-            variant="green"
+            variant="slate"
             labelId={`field-ownership-${context.id}`}
           />
         </div>

--- a/src/components/nodes/ContextNode.tsx
+++ b/src/components/nodes/ContextNode.tsx
@@ -7,7 +7,7 @@ import type { BoundedContext } from '../../model/types'
 import { Archive, CloudFog } from 'lucide-react'
 import { getContextTooltipLines } from '../../lib/contextTooltip'
 import { coordinateSpaceFor } from '../../lib/canvasViewModel'
-import { getContextNodeBorderStyle } from '../../lib/nodeStyles'
+import { getContextNodeBorderStyle, OWNERSHIP_FILL_COLORS } from '../../lib/nodeStyles'
 import { NODE_SIZES } from '../../lib/canvasConstants'
 import { InfoTooltip } from '../InfoTooltip'
 import { LEGACY_CONTEXT, BIG_BALL_OF_MUD } from '../../model/conceptDefinitions'
@@ -137,11 +137,6 @@ export function ContextNode({ data }: NodeProps) {
   }
 
   // Fill color based on colorByMode setting
-  const OWNERSHIP_COLORS = {
-    ours: '#d1fae5', // green-100
-    internal: '#dbeafe', // blue-100
-    external: '#fed7aa', // orange-200
-  }
   const STRATEGIC_COLORS = {
     core: '#f8e7a1', // yellow
     supporting: '#dbeafe', // blue
@@ -149,7 +144,7 @@ export function ContextNode({ data }: NodeProps) {
   }
   const fillColor =
     colorByMode === 'ownership'
-      ? OWNERSHIP_COLORS[context.ownership || 'ours']
+      ? OWNERSHIP_FILL_COLORS[context.ownership || 'ours']
       : STRATEGIC_COLORS[context.strategicClassification || 'generic']
 
   // Reserve horizontal space for the absolutely-positioned identity icons in

--- a/src/lib/nodeStyles.ts
+++ b/src/lib/nodeStyles.ts
@@ -1,5 +1,11 @@
 import type { ContextOwnership } from '../model/types'
 
+export const OWNERSHIP_FILL_COLORS: Record<ContextOwnership, string> = {
+  ours: '#d1fae5', // green-100
+  internal: '#dbeafe', // blue-100
+  external: '#fed7aa', // orange-200
+}
+
 type BoundaryIntegrity = 'strong' | 'moderate' | 'weak'
 
 interface ContextStyleInput {


### PR DESCRIPTION
Closes #35

## Problem

When selecting the team ownership type in the inspector, the active pill was always green. Since green is the canvas fill color for "Our Team", a green highlight on "Internal" or "External" reads as if those are also "Our Team".

## Change

- Each ownership pill now shows a small color swatch matching its on-canvas fill: green (Our Team), blue (Internal), orange (External). This mirrors the existing Boundary and Code Size pills that preview their on-canvas appearance.
- The pill group switches from `variant="green"` to `variant="slate"`, so the active state is a neutral highlight that no longer implies a specific ownership.
- Ownership fill colors are extracted to a shared `OWNERSHIP_FILL_COLORS` constant in `nodeStyles.ts`, so the inspector swatches and the canvas nodes draw from one source of truth (no drift).

## Verification

- `npm run typecheck` and `npm run lint`: 0 errors.
- Inspector + node tests: 101 passing.
- Browser-verified: selecting Internal shows a neutral active state and a blue swatch, and the canvas node turns blue to match.