### PR TITLE
ci: run build check on pull requests targeting main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -11,7 +14,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
+  group: "pages-${{ github.ref }}"
   cancel-in-progress: false
 
 jobs:
@@ -45,17 +48,21 @@ jobs:
           VITE_POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
 
       - name: Copy index.html to 404.html for SPA routing
+        if: github.event_name == 'push'
         run: cp dist/index.html dist/404.html
 
       - name: Setup Pages
+        if: github.event_name == 'push'
         uses: actions/configure-pages@v4
 
       - name: Upload artifact
+        if: github.event_name == 'push'
         uses: actions/upload-pages-artifact@v3
         with:
           path: './dist'
 
   deploy:
+    if: github.event_name == 'push'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Why

`main` requires the `build` status check, but the deploy workflow only ran on push to `main`. The required check never appeared on a PR, so PRs were permanently `BLOCKED` and could only land via an admin override.

## Change

- Add a `pull_request` trigger (targeting `main`) so the `build` job (typecheck, lint, format:check, build) runs on PRs and satisfies the required check.
- Gate the Pages-specific steps (Setup Pages, Upload artifact, 404 copy) and the `deploy` job to `push` events, so PRs validate without deploying to production.
- Scope `concurrency` per ref so PR builds and the `main` deploy don't contend for a single lock.

## Verification

This PR exercises the new trigger: the `build` check should now appear on it and be mergeable without an admin override.